### PR TITLE
Fix dependency list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ langchain-text-splitters==0.1.*
 chromadb>=0.5
 python-dotenv>=1.0
 openai>=1.12          # cliente oficial
+langchain-chroma==0.1.*
+rapidfuzz>=3.0
+beautifulsoup4>=4.12
+unstructured>=0.11


### PR DESCRIPTION
## Summary
- add missing packages for bs4, rapidfuzz, unstructured and Chroma

## Testing
- `python -m py_compile src/ingest.py`
- `pip install chromadb langchain-community langchain-openai langchain-text-splitters python-dotenv rapidfuzz bs4 unstructured` *(fails: Could not find a version that satisfies the requirement chromadb)*

------
https://chatgpt.com/codex/tasks/task_e_6872eb42bf608332a501537ae0055d0b